### PR TITLE
#3629 Add AI review announcement to gallery home

### DIFF
--- a/src/components/gallery.module.css
+++ b/src/components/gallery.module.css
@@ -23,6 +23,32 @@
     }
 }
 
+.global-alert {
+    margin: var(--mantine-spacing-sm);
+    margin-bottom: 0;
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    display: flex;
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    min-height: 44px;
+    line-height: 1.45;
+    color: var(--mantine-color-blue-8);
+    background: var(--mantine-color-blue-0);
+    border-radius: var(--mantine-radius-sm);
+}
+
+.global-alert-icon {
+    flex: 0 0 auto;
+    width: 18px;
+    height: 18px;
+}
+
+.global-alert-title {
+    color: var(--mantine-color-blue-9);
+}
+
 .notification {
     margin-top: var(--mantine-spacing-sm);
 }

--- a/src/components/gallery.tsx
+++ b/src/components/gallery.tsx
@@ -3,7 +3,7 @@ import rmgRuntime from '@railmapgen/rmg-runtime';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { IoMdHeart } from 'react-icons/io';
-import { MdAdd, MdOutlineWarning } from 'react-icons/md';
+import { MdAdd, MdOutlineAutoAwesome, MdOutlineWarning } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 
 import { useRootDispatch, useRootSelector } from '../redux';
@@ -25,6 +25,7 @@ import { TemplateCard } from './template-card';
 import {
     ActionIcon,
     Affix,
+    Anchor,
     Group,
     NativeSelect,
     Notification,
@@ -228,6 +229,14 @@ export default function GalleryView() {
 
     return (
         <RMPage>
+            <div className={classes['global-alert']} role="status">
+                <MdOutlineAutoAwesome className={classes['global-alert-icon']} />
+                <strong className={classes['global-alert-title']}>{t('gallery.aiReview.title')}</strong>
+                <span>{t('gallery.aiReview.content')}</span>
+                <Anchor href={t('gallery.aiReview.linkHref')} target="_blank" rel="noreferrer">
+                    {t('gallery.aiReview.linkText')}
+                </Anchor>
+            </div>
             <Tabs
                 value={type}
                 onChange={tab => {

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -37,6 +37,12 @@
             "label": "Sort by",
             "alphabetical": "Alphabetically",
             "updateTime": "Update time"
+        },
+        "aiReview": {
+            "title": "AI agents now assist Gallery submission review",
+            "content": "We are using AI agents with the standard review workflow to handle the resource submission backlog faster while preserving review quality.",
+            "linkText": "Read the update",
+            "linkHref": "https://railmapgen.org/rmt-blog/en-US/rmp-gallery-ai-review/"
         }
     },
     "details": {

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -37,6 +37,12 @@
             "label": "並び替え",
             "alphabetical": "アルファベット順",
             "updateTime": "更新日時"
+        },
+        "aiReview": {
+            "title": "人工知能エージェントが画廊投稿の審査を補助しています",
+            "content": "標準作業手順に沿って人工知能エージェントを活用し、審査品質を保ちながらリソース投稿の滞留をより早く処理しています。",
+            "linkText": "最近の成果を見る",
+            "linkHref": "https://railmapgen.org/rmt-blog/ja-JP/rmp-gallery-ai-review/"
         }
     },
     "details": {

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -37,6 +37,12 @@
             "label": "정렬 기준",
             "alphabetical": "알파벳순",
             "updateTime": "업데이트 시간순"
+        },
+        "aiReview": {
+            "title": "인공지능 에이전트가 갤러리 제출 검토를 돕고 있습니다",
+            "content": "표준 작업 절차에 따라 인공지능 에이전트를 활용해 검토 품질을 유지하면서 리소스 제출 적체를 더 빠르게 처리하고 있습니다.",
+            "linkText": "최근 성과 보기",
+            "linkHref": "https://railmapgen.org/rmt-blog/ko-KR/rmp-gallery-ai-review/"
         }
     },
     "details": {

--- a/src/i18n/translations/zh-Hans.json
+++ b/src/i18n/translations/zh-Hans.json
@@ -37,6 +37,12 @@
             "label": "排序方式",
             "alphabetical": "按字母顺序",
             "updateTime": "更新时间"
+        },
+        "aiReview": {
+            "title": "人工智能体正在辅助审核画廊投稿",
+            "content": "我们已开始使用人工智能体按标准作业流程辅助审核资源投稿，以更快处理积压并保持审核质量。",
+            "linkText": "查看近期成果",
+            "linkHref": "https://railmapgen.org/rmt-blog/zh-CN/rmp-gallery-ai-review/"
         }
     },
     "details": {

--- a/src/i18n/translations/zh-Hant.json
+++ b/src/i18n/translations/zh-Hant.json
@@ -37,6 +37,12 @@
             "label": "排序方式",
             "alphabetical": "按字母順序",
             "updateTime": "更新時間"
+        },
+        "aiReview": {
+            "title": "人工智能體正在輔助審核畫廊投稿",
+            "content": "我們已開始使用人工智能體按標準作業流程輔助審核資源投稿，以更快處理積壓並保持審核質量。",
+            "linkText": "查看近期成果",
+            "linkHref": "https://railmapgen.org/rmt-blog/zh-HK/rmp-gallery-ai-review/"
         }
     },
     "details": {


### PR DESCRIPTION
Closes #3629

Summary:
- Add a global AI-assisted review announcement above the gallery tabs.
- Link the alert to the localized rmt-blog article.
- Add localized alert copy for zh-Hans, zh-Hant, en, ja, and ko.

Verification:
- npx tsc --noEmit
- npm run lint
- npm test -- --run
- npm run build

Note:
- Local visual verification was not performed because the existing 127.0.0.1:5173 service is not serving this worktree's current bundle.